### PR TITLE
replace texture2d to texture

### DIFF
--- a/shaders/3d_fragment.frag
+++ b/shaders/3d_fragment.frag
@@ -10,5 +10,5 @@ out vec4 fragColor;
 uniform sampler2D textureSampler;
 
 void main() {
-    fragColor = texture2D(textureSampler, outputTextureCoordinate);
+    fragColor = texture(textureSampler, outputTextureCoordinate);
 }


### PR DESCRIPTION
It's to fix this error:
Message: SHADER_ID_COMPILE error has been generated. GLSL compile failed for shader 3, "": ERROR: 0:14: 'function' : is removed in Forward Compatible context texture2D